### PR TITLE
Rewrite hashicorp/vault/api => openbao/openbao/api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,7 +77,7 @@ linters-settings:
           - github.com/hashicorp/hcl
           - github.com/hashicorp/logutils
           - github.com/hashicorp/nomad/api
-          - github.com/hashicorp/vault/api
+          - github.com/openbao/openbao/api
           - github.com/imdario/mergo
           - github.com/mitchellh/go-homedir
           - github.com/mitchellh/hashstructure

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-template/signals"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 func TestMain(m *testing.M) {

--- a/config/vault.go
+++ b/config/vault.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 const (

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 func TestVaultConfig_Copy(t *testing.T) {

--- a/dependency/client_set.go
+++ b/dependency/client_set.go
@@ -16,8 +16,8 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	rootcerts "github.com/hashicorp/go-rootcerts"
 	nomadapi "github.com/hashicorp/nomad/api"
-	vaultapi "github.com/hashicorp/vault/api"
-	vaultkubernetesauth "github.com/hashicorp/vault/api/auth/kubernetes"
+	vaultapi "github.com/openbao/openbao/api"
+	vaultkubernetesauth "github.com/openbao/openbao/api/auth/kubernetes"
 )
 
 // ClientSet is a collection of clients that dependencies use to communicate

--- a/dependency/client_set_test.go
+++ b/dependency/client_set_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-template/test"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	nomadapi "github.com/hashicorp/nomad/api"
-	vapi "github.com/hashicorp/vault/api"
+	vapi "github.com/openbao/openbao/api"
 )
 
 const (

--- a/dependency/vault_common.go
+++ b/dependency/vault_common.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 var (

--- a/dependency/vault_common_test.go
+++ b/dependency/vault_common_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 func init() {

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-template/renderer"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 func Test_VaultPKI_uniqueID(t *testing.T) {

--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/pkg/errors"
 )
 

--- a/dependency/vault_read_test.go
+++ b/dependency/vault_read_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dependency/vault_token.go
+++ b/dependency/vault_token.go
@@ -4,7 +4,7 @@
 package dependency
 
 import (
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/pkg/errors"
 )
 

--- a/dependency/vault_token_test.go
+++ b/dependency/vault_token_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/dependency/vault_write.go
+++ b/dependency/vault_write.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/pkg/errors"
 )
 

--- a/dependency/vault_write_test.go
+++ b/dependency/vault_write_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/docs/templating-language.md
+++ b/docs/templating-language.md
@@ -565,7 +565,7 @@ they will have access to plain-text secrets.
 Please note that Vault does not support blocking queries. As a result, Consul
 Template will not immediately reload in the event a secret is changed as it
 does with Consul's key-value store. Consul Template will renew the secret with
-Vault's [Renewer API](https://godoc.org/github.com/hashicorp/vault/api#Renewer).
+Vault's [Renewer API](https://godoc.org/github.com/openbao/openbao/api#Renewer).
 The Renew API tries to use most of the time the secret is good, renewing at
 around 90% of the lease time (as set by Vault).
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/hashicorp/consul-template
 
 go 1.21
 
+// Use a temporary hack to pull in the latest API version via commit hash
+// until we've tagged a new API version in openbao's repo.
+replace github.com/openbao/openbao/api v1.9.2 => github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1
+
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -17,11 +21,11 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/nomad/api v0.0.0-20230103221135-ce00d683f9be
 	github.com/hashicorp/serf v0.10.1 // indirect
-	github.com/hashicorp/vault/api v1.10.0
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/openbao/openbao/api v1.9.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.14.0 // indirect
@@ -31,7 +35,7 @@ require (
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/hashicorp/vault/api/auth/kubernetes v0.5.0
+	github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	golang.org/x/text v0.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -135,10 +135,6 @@ github.com/hashicorp/nomad/api v0.0.0-20230103221135-ce00d683f9be h1:bJ/jBA5pt/5
 github.com/hashicorp/nomad/api v0.0.0-20230103221135-ce00d683f9be/go.mod h1:EM/2XaEwHziSB4NdWZ6MfE65TcvgWwVawOUBT8kVRqE=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/hashicorp/vault/api v1.10.0 h1:/US7sIjWN6Imp4o/Rj1Ce2Nr5bki/AXi9vAW3p2tOJQ=
-github.com/hashicorp/vault/api v1.10.0/go.mod h1:jo5Y/ET+hNyz+JnKDt8XLAdKs+AM0G5W0Vp1IrFI8N8=
-github.com/hashicorp/vault/api/auth/kubernetes v0.5.0 h1:CXO0fD7M3iCGovP/UApeHhPcH4paDFKcu7AjEXi94rI=
-github.com/hashicorp/vault/api/auth/kubernetes v0.5.0/go.mod h1:afrElBIO9Q4sHFVuVWgNevG4uAs1bT2AZFA9aEiI608=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -201,6 +197,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1 h1:tz26SdhQlJpHSqjl+zPHhuU97/UEV19xmFkwvgE3Dd8=
+github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1/go.mod h1:rpTE5IyLk+IdcK1wVRfV6uzYcBgAyKK6fjwiaYgO+Oc=
+github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1 h1:+64SuQOMb7mb3GcbxxJ17BgOCUZCQgid7AiO43poUrA=
+github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1/go.mod h1:aQFIYCMM+Eh/axvoRMeeAwwRQiYGhmLeC+tuWwelDtY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/watch/vault_token.go
+++ b/watch/vault_token.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/consul-template/config"
 	dep "github.com/hashicorp/consul-template/dependency"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 // VaultTokenWatcher monitors the vault token for updates

--- a/watch/vault_token_test.go
+++ b/watch/vault_token_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/consul-template/config"
 	dep "github.com/hashicorp/consul-template/dependency"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 // approle auto-auth setup in watch_test.go, TestMain()

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	dep "github.com/hashicorp/consul-template/dependency"
-	"github.com/hashicorp/vault/api"
+	"github.com/openbao/openbao/api"
 )
 
 const (


### PR DESCRIPTION
This uses an earlier commit for the time being. 

Depending on the state of various proposals, while this repository was (AFAIK?) never part of upstream's main repository (instead coming from Consul), we could consider importing this under `sdk/` for simplicity. 