### PR TITLE
Rename project to openbao-template, use BAO_ vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.36.0-bao
+
+NEW FEATURES:
+* Read `BAO_`-prefixed variables over `VAULT_`-prefixed variables,
+  switching to OpenBao's API client.
+
+REMOVALS:
+* Consul & Nomad templating functionality. This fork will be for
+  OpenBao only.
+
 ## v0.35.0 (November 7, 2023)
 
 NEW FEATURES:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
 GOTAGS ?=
 
 # Get the project metadata
-OWNER := "hashicorp"
-NAME := "consul-template"
+OWNER := "openbao"
+NAME := "openbao-template"
 PROJECT := $(shell go list -m | awk "/${NAME}/ {print $0}" )
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD || echo release)
 VERSION := $(shell awk -F\" '/^[ \t]+Version/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")
@@ -41,8 +41,8 @@ dev:
 docker:
 	@env CGO_ENABLED="0" go build -ldflags "${LD_FLAGS}" -o $(NAME)
 	mkdir -p dist/linux/amd64/
-	cp consul-template dist/linux/amd64/
-	env DOCKER_BUILDKIT=1 docker build -t consul-template .
+	cp openbao-template dist/linux/amd64/
+	env DOCKER_BUILDKIT=1 docker build -t openbao-template .
 .PHONY: docker
 
 # test runs the test suite.
@@ -60,7 +60,7 @@ test-race:
 # _cleanup removes any previous binaries
 clean:
 	@rm -rf "${CURRENT_DIR}/dist/"
-	@rm -f "consul-template"
+	@rm -f "openbao-template"
 .PHONY: clean
 
 # Add/Update the "Table Of Contents" in the README.md
@@ -78,3 +78,8 @@ lint:
 	@echo "==> Running golangci-lint"
 	GOWORK=off golangci-lint run --build-tags '$(GOTAGS)'
 .PHONY: lint
+
+# format
+fmt:
+	@echo "==> Running gofumpt"
+	go run mvdan.cc/gofumpt@latest -w -l *.go */*.go

--- a/child/child.go
+++ b/child/child.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/signals"
 )
 
 var (

--- a/child/child_test.go
+++ b/child/child_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/signals"
 
 	"github.com/hashicorp/go-gatedio"
 	"golang.org/x/sys/unix"

--- a/cli.go
+++ b/cli.go
@@ -13,12 +13,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openbao/consul-template/config"
-	"github.com/openbao/consul-template/logging"
-	"github.com/openbao/consul-template/manager"
-	"github.com/openbao/consul-template/service_os"
-	"github.com/openbao/consul-template/signals"
-	"github.com/openbao/consul-template/version"
+	"github.com/openbao/openbao-template/config"
+	"github.com/openbao/openbao-template/logging"
+	"github.com/openbao/openbao-template/manager"
+	"github.com/openbao/openbao-template/service_os"
+	"github.com/openbao/openbao-template/signals"
+	"github.com/openbao/openbao-template/version"
 )
 
 // Exit codes are int values that represent an exit code for a particular error.
@@ -681,7 +681,7 @@ Options:
       Adds a new template to watch on disk in the format 'in:out(:command)'
 
   -template-error-fatal=<bool>
-      Control whether template errors cause consul-template to immediately exit.
+      Control whether template errors cause openbao-template to immediately exit.
       This overrides the per-template setting.
 
   -vault-addr=<address>

--- a/cli_test.go
+++ b/cli_test.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	gatedio "github.com/hashicorp/go-gatedio"
-	"github.com/openbao/consul-template/config"
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/config"
+	"github.com/openbao/openbao-template/signals"
 )
 
 func TestCLI_ParseFlags(t *testing.T) {
@@ -171,11 +171,11 @@ func TestCLI_ParseFlags(t *testing.T) {
 		},
 		{
 			"exec-env-denylist",
-			[]string{"-exec-env-denylist", "VAULT_*"},
+			[]string{"-exec-env-denylist", "BAO_*"},
 			&config.Config{
 				Exec: &config.ExecConfig{
 					Env: &config.EnvConfig{
-						Denylist: []string{"VAULT_*"},
+						Denylist: []string{"BAO_*"},
 					},
 				},
 			},
@@ -184,13 +184,13 @@ func TestCLI_ParseFlags(t *testing.T) {
 		{
 			"exec-env-denylist-multiple",
 			[]string{
-				"-exec-env-denylist", "VAULT_*",
+				"-exec-env-denylist", "BAO_*",
 			},
 			&config.Config{
 				Exec: &config.ExecConfig{
 					Env: &config.EnvConfig{
 						Denylist: []string{
-							"VAULT_*",
+							"BAO_*",
 						},
 					},
 				},
@@ -679,7 +679,7 @@ func TestCLI_Run(t *testing.T) {
 			out := gatedio.NewByteBuffer()
 			cli := NewCLI(out, out)
 
-			tc.args = append([]string{"consul-template"}, tc.args...)
+			tc.args = append([]string{"openbao-template"}, tc.args...)
 			exit := cli.Run(tc.args)
 			tc.f(t, exit, out.String())
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -17,9 +17,10 @@ import (
 	"github.com/hashicorp/hcl"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
-	"github.com/openbao/consul-template/signals"
-
+	"github.com/openbao/openbao/api"
 	"github.com/pkg/errors"
+
+	"github.com/openbao/openbao-template/signals"
 )
 
 const (
@@ -403,7 +404,6 @@ func FromPath(path string) (*Config, error) {
 
 			return nil
 		})
-
 		if err != nil {
 			return nil, errors.Wrap(err, "walk error")
 		}
@@ -592,7 +592,7 @@ func (c *Config) Finalize() {
 
 func stringFromEnv(list []string, def string) *string {
 	for _, s := range list {
-		if v := os.Getenv(s); v != "" {
+		if v := api.ReadBaoVariable(s); v != "" {
 			return String(strings.TrimSpace(v))
 		}
 	}
@@ -611,7 +611,7 @@ func stringFromFile(list []string, def string) *string {
 
 func antiboolFromEnv(list []string, def bool) *bool {
 	for _, s := range list {
-		if v := os.Getenv(s); v != "" {
+		if v := api.ReadBaoVariable(s); v != "" {
 			b, err := strconv.ParseBool(v)
 			if err == nil {
 				return Bool(!b)
@@ -623,7 +623,7 @@ func antiboolFromEnv(list []string, def bool) *bool {
 
 func boolFromEnv(list []string, def bool) *bool {
 	for _, s := range list {
-		if v := os.Getenv(s); v != "" {
+		if v := api.ReadBaoVariable(s); v != "" {
 			b, err := strconv.ParseBool(v)
 			if err == nil {
 				return Bool(b)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,12 +12,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/signals"
 	"github.com/openbao/openbao/api"
 )
 
 func TestMain(m *testing.M) {
 	// clear out any potential local config for tests
+	os.Unsetenv("BAO_ADDR")
+	os.Unsetenv("BAO_TOKEN")
+	os.Unsetenv("BAO_DEV_ROOT_TOKEN_ID")
 	os.Unsetenv("VAULT_ADDR")
 	os.Unsetenv("VAULT_TOKEN")
 	os.Unsetenv("VAULT_DEV_ROOT_TOKEN_ID")
@@ -2090,7 +2093,7 @@ func TestDefaultConfig(t *testing.T) {
 		err bool
 	}{
 		{
-			"VAULT_ADDR",
+			"BAO_ADDR",
 			"http://1.2.3.4:8200",
 			&Config{
 				Vault: &VaultConfig{
@@ -2100,7 +2103,7 @@ func TestDefaultConfig(t *testing.T) {
 			false,
 		},
 		{
-			"VAULT_TOKEN",
+			"BAO_TOKEN",
 			"abcd1234",
 			&Config{
 				Vault: &VaultConfig{
@@ -2110,7 +2113,7 @@ func TestDefaultConfig(t *testing.T) {
 			false,
 		},
 		{
-			"VAULT_UNWRAP_TOKEN",
+			"BAO_UNWRAP_TOKEN",
 			"true",
 			&Config{
 				Vault: &VaultConfig{
@@ -2120,7 +2123,7 @@ func TestDefaultConfig(t *testing.T) {
 			false,
 		},
 		{
-			"VAULT_UNWRAP_TOKEN",
+			"BAO_UNWRAP_TOKEN",
 			"false",
 			&Config{
 				Vault: &VaultConfig{
@@ -2166,41 +2169,41 @@ func TestDefaultConfig(t *testing.T) {
 			false,
 		},
 		{
-			"VAULT_K8S_AUTH_ROLE_NAME",
-			"VAULT_K8S_AUTH_ROLE_NAME",
+			"BAO_K8S_AUTH_ROLE_NAME",
+			"BAO_K8S_AUTH_ROLE_NAME",
 			&Config{
 				Vault: &VaultConfig{
-					K8SAuthRoleName: String("VAULT_K8S_AUTH_ROLE_NAME"),
+					K8SAuthRoleName: String("BAO_K8S_AUTH_ROLE_NAME"),
 				},
 			},
 			false,
 		},
 		{
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN",
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN",
 			&Config{
 				Vault: &VaultConfig{
-					K8SServiceAccountToken: String("VAULT_K8S_SERVICE_ACCOUNT_TOKEN"),
+					K8SServiceAccountToken: String("BAO_K8S_SERVICE_ACCOUNT_TOKEN"),
 				},
 			},
 			false,
 		},
 		{
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
 			&Config{
 				Vault: &VaultConfig{
-					K8SServiceAccountTokenPath: String("VAULT_K8S_SERVICE_ACCOUNT_TOKEN_PATH"),
+					K8SServiceAccountTokenPath: String("BAO_K8S_SERVICE_ACCOUNT_TOKEN_PATH"),
 				},
 			},
 			false,
 		},
 		{
-			"VAULT_K8S_SERVICE_MOUNT_PATH",
-			"VAULT_K8S_SERVICE_MOUNT_PATH",
+			"BAO_K8S_SERVICE_MOUNT_PATH",
+			"BAO_K8S_SERVICE_MOUNT_PATH",
 			&Config{
 				Vault: &VaultConfig{
-					K8SServiceMountPath: String("VAULT_K8S_SERVICE_MOUNT_PATH"),
+					K8SServiceMountPath: String("BAO_K8S_SERVICE_MOUNT_PATH"),
 				},
 			},
 			false,

--- a/config/convert.go
+++ b/config/convert.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/signals"
 )
 
 // Bool returns a pointer to the given bool.

--- a/config/convert_test.go
+++ b/config/convert_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbao/consul-template/signals"
+	"github.com/openbao/openbao-template/signals"
 )
 
 func TestBool(t *testing.T) {

--- a/config/dedup.go
+++ b/config/dedup.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// DefaultDedupPrefix is the default prefix used for deduplication mode.
-	DefaultDedupPrefix = "consul-template/dedup/"
+	DefaultDedupPrefix = "openbao-template/dedup/"
 
 	// DefaultDedupTTL is the default TTL for deduplicate mode.
 	DefaultDedupTTL = 15 * time.Second

--- a/config/logfile.go
+++ b/config/logfile.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openbao/consul-template/version"
+	"github.com/openbao/openbao-template/version"
 )
 
 var (

--- a/config/syslog.go
+++ b/config/syslog.go
@@ -6,7 +6,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/openbao/consul-template/version"
+	"github.com/openbao/openbao-template/version"
 )
 
 const (

--- a/config/transport.go
+++ b/config/transport.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openbao/consul-template/dependency"
+	"github.com/openbao/openbao-template/dependency"
 )
 
 const (

--- a/config/vault.go
+++ b/config/vault.go
@@ -13,7 +13,7 @@ import (
 const (
 	// XXX Change use to api.EnvVaultSkipVerify once we've updated vendored
 	// vault to version 1.1.0 or newer.
-	EnvVaultSkipVerify = "VAULT_SKIP_VERIFY"
+	EnvVaultSkipVerify = "BAO_SKIP_VERIFY"
 
 	// DefaultVaultRenewToken is the default value for if the Vault token should
 	// be renewed.
@@ -56,7 +56,7 @@ type VaultConfig struct {
 	Enabled *bool `mapstructure:"enabled"`
 
 	// Namespace is the Vault namespace to use for reading/writing secrets. This can
-	// also be set via the VAULT_NAMESPACE environment variable.
+	// also be set via the BAO_NAMESPACE environment variable.
 	Namespace *string `mapstructure:"namespace"`
 
 	// RenewToken renews the Vault token.
@@ -69,7 +69,7 @@ type VaultConfig struct {
 	SSL *SSLConfig `mapstructure:"ssl"`
 
 	// Token is the Vault token to communicate with for requests. It may be
-	// a wrapped token or a real token. This can also be set via the VAULT_TOKEN
+	// a wrapped token or a real token. This can also be set via the BAO_TOKEN
 	// environment variable, or via the VaultAgentTokenFile.
 	Token *string `mapstructure:"token" json:"-"`
 
@@ -107,7 +107,7 @@ type VaultConfig struct {
 	// authentication makes it easy to introduce a Vault token into
 	// a Kubernetes Pod.
 	//
-	// This can also be set via the VAULT_K8S_AUTH_ROLE_NAME.
+	// This can also be set via the BAO_K8S_AUTH_ROLE_NAME.
 	K8SAuthRoleName *string `mapstructure:"k8s_auth_role_name"`
 	// K8SServiceAccountTokenPath is the path of file that contains
 	// a K8SServiceAccountToken. It will be ignored if K8SServiceAccountToken
@@ -115,16 +115,16 @@ type VaultConfig struct {
 	//
 	// Default value is "/run/secrets/kubernetes.io/serviceaccount/token".
 	//
-	// This can also be set via the VAULT_K8S_SERVICE_ACCOUNT_TOKEN_PATH.
+	// This can also be set via the BAO_K8S_SERVICE_ACCOUNT_TOKEN_PATH.
 	K8SServiceAccountTokenPath *string `mapstructure:"k8s_service_account_token_path"`
 	// Value of an account token for k8s auth method.
 	//
-	// This can also be set via the VAULT_K8S_SERVICE_ACCOUNT_TOKEN.
+	// This can also be set via the BAO_K8S_SERVICE_ACCOUNT_TOKEN.
 	K8SServiceAccountToken *string `mapstructure:"k8s_service_account_token"`
 	// K8SServiceMountPath is a part of k8s login path, by default the value is
 	// "kubernetes". In this case a full path will be "auth/kubernetes/login".
 	//
-	// This can also be set via the VAULT_K8S_SERVICE_MOUNT_PATH.
+	// This can also be set via the BAO_K8S_SERVICE_MOUNT_PATH.
 	K8SServiceMountPath *string `mapstructure:"k8s_service_mount_path"`
 }
 
@@ -285,7 +285,7 @@ func (c *VaultConfig) Finalize() {
 	}
 
 	if c.Namespace == nil {
-		c.Namespace = stringFromEnv([]string{"VAULT_NAMESPACE"}, "")
+		c.Namespace = stringFromEnv([]string{"BAO_NAMESPACE"}, "")
 	}
 
 	if c.Retry == nil {
@@ -328,10 +328,10 @@ func (c *VaultConfig) Finalize() {
 	// Order of precedence
 	// 1. `vault_agent_token_file` configuration value
 	// 2. `token` configuration value`
-	// 3. `VAULT_TOKEN` environment variable
+	// 3. `BAO_TOKEN` environment variable
 	if c.Token == nil {
 		c.Token = stringFromEnv([]string{
-			"VAULT_TOKEN",
+			"BAO_TOKEN",
 		}, "")
 	}
 
@@ -356,7 +356,7 @@ func (c *VaultConfig) Finalize() {
 			default_renew = false
 		}
 		c.RenewToken = boolFromEnv([]string{
-			"VAULT_RENEW_TOKEN",
+			"BAO_RENEW_TOKEN",
 		}, default_renew)
 	}
 
@@ -367,7 +367,7 @@ func (c *VaultConfig) Finalize() {
 
 	if c.UnwrapToken == nil {
 		c.UnwrapToken = boolFromEnv([]string{
-			"VAULT_UNWRAP_TOKEN",
+			"BAO_UNWRAP_TOKEN",
 		}, DefaultVaultUnwrapToken)
 	}
 
@@ -385,22 +385,22 @@ func (c *VaultConfig) Finalize() {
 
 	if c.K8SAuthRoleName == nil {
 		c.K8SAuthRoleName = stringFromEnv([]string{
-			"VAULT_K8S_AUTH_ROLE_NAME",
+			"BAO_K8S_AUTH_ROLE_NAME",
 		}, "")
 	}
 	if c.K8SServiceAccountToken == nil {
 		c.K8SServiceAccountToken = stringFromEnv([]string{
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN",
 		}, "")
 	}
 	if c.K8SServiceAccountTokenPath == nil {
 		c.K8SServiceAccountTokenPath = stringFromEnv([]string{
-			"VAULT_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
+			"BAO_K8S_SERVICE_ACCOUNT_TOKEN_PATH",
 		}, DefaultK8SServiceAccountTokenPath)
 	}
 	if c.K8SServiceMountPath == nil {
 		c.K8SServiceMountPath = stringFromEnv([]string{
-			"VAULT_K8S_SERVICE_MOUNT_PATH",
+			"BAO_K8S_SERVICE_MOUNT_PATH",
 		}, DefaultK8SServiceMountPath)
 	}
 }

--- a/dependency/client_set_test.go
+++ b/dependency/client_set_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/openbao/consul-template/test"
+	"github.com/openbao/openbao-template/test"
 	"github.com/openbao/openbao/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/openbao/consul-template/test"
+	"github.com/openbao/openbao-template/test"
 	vapi "github.com/openbao/openbao/api"
 )
 

--- a/dependency/vault_agent_token_test.go
+++ b/dependency/vault_agent_token_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbao/consul-template/renderer"
+	"github.com/openbao/openbao-template/renderer"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/dependency/vault_pki_test.go
+++ b/dependency/vault_pki_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openbao/consul-template/renderer"
+	"github.com/openbao/openbao-template/renderer"
 	"github.com/openbao/openbao/api"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,9 @@
-module github.com/openbao/consul-template
+module github.com/openbao/openbao-template
 
 go 1.21
 
-// Use a temporary hack to pull in the latest API version via commit hash
-// until we've tagged a new API version in openbao's repo.
-replace github.com/openbao/openbao/api v1.9.2 => github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1
-
-replace github.com/openbao/openbao/api/auth/kubernetes v0.0.0-00010101000000-000000000000 => github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1
+// Temporary hack until go.mods are updated:
+replace github.com/openbao/openbao/api v1.9.2 => github.com/openbao/openbao/api v0.0.0-20240227182507-a8c90d250c17
 
 require (
 	github.com/BurntSushi/toml v1.3.2
@@ -32,7 +29,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/openbao/openbao/api v1.9.2
-	github.com/openbao/openbao/api/auth/kubernetes v0.0.0-00010101000000-000000000000
+	github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20240227182507-a8c90d250c17
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,10 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1 h1:tz26SdhQlJpHSqjl+zPHhuU97/UEV19xmFkwvgE3Dd8=
-github.com/openbao/openbao/api v0.0.0-20231222185543-009633ab13d1/go.mod h1:rpTE5IyLk+IdcK1wVRfV6uzYcBgAyKK6fjwiaYgO+Oc=
-github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1 h1:+64SuQOMb7mb3GcbxxJ17BgOCUZCQgid7AiO43poUrA=
-github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20231222185543-009633ab13d1/go.mod h1:aQFIYCMM+Eh/axvoRMeeAwwRQiYGhmLeC+tuWwelDtY=
+github.com/openbao/openbao/api v0.0.0-20240227182507-a8c90d250c17 h1:JE6Npq/JIiz9UpBiVvMAXd2APHmRS723j632Qdc99p8=
+github.com/openbao/openbao/api v0.0.0-20240227182507-a8c90d250c17/go.mod h1:rpTE5IyLk+IdcK1wVRfV6uzYcBgAyKK6fjwiaYgO+Oc=
+github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20240227182507-a8c90d250c17 h1:JEeYyBNOZFkOE4ftCPCqnriREN4wYbXUM4GZZ9EEEG0=
+github.com/openbao/openbao/api/auth/kubernetes v0.0.0-20240227182507-a8c90d250c17/go.mod h1:aQFIYCMM+Eh/axvoRMeeAwwRQiYGhmLeC+tuWwelDtY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/logutils"
-	"github.com/openbao/consul-template/config"
+	"github.com/openbao/openbao-template/config"
 	"github.com/stretchr/testify/require"
 )
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	cnf "github.com/openbao/consul-template/config"
+	cnf "github.com/openbao/openbao-template/config"
 
 	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hashicorp/logutils"

--- a/logging/syslog_test.go
+++ b/logging/syslog_test.go
@@ -25,7 +25,7 @@ func TestSyslogFilter(t *testing.T) {
 		}
 	}
 
-	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "consul-template")
+	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "openbao-template")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package main // import "github.com/openbao/consul-template"
+package main // import "github.com/openbao/openbao-template"
 
 import "os"
 

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openbao/consul-template/test"
+	"github.com/openbao/openbao-template/test"
 )
 
 func TestMain(m *testing.M) {

--- a/manager/example_extfuncmap_test.go
+++ b/manager/example_extfuncmap_test.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"text/template"
 
-	"github.com/openbao/consul-template/config"
-	"github.com/openbao/consul-template/manager"
+	"github.com/openbao/openbao-template/config"
+	"github.com/openbao/openbao-template/manager"
 )
 
 // ExampleCustomFuncMap demonstrates a minimum [consul-template/manager]

--- a/manager/example_manager_test.go
+++ b/manager/example_manager_test.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/openbao/consul-template/config"
-	"github.com/openbao/consul-template/manager"
+	"github.com/openbao/openbao-template/config"
+	"github.com/openbao/openbao-template/manager"
 )
 
 // This example demonstrates a minimum configuration to create, configure, and

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
-	"github.com/openbao/consul-template/test"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
+	"github.com/openbao/openbao-template/test"
 )
 
 var testClients *dep.ClientSet

--- a/manager/runner.go
+++ b/manager/runner.go
@@ -15,12 +15,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/openbao/consul-template/child"
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
-	"github.com/openbao/consul-template/renderer"
-	"github.com/openbao/consul-template/template"
-	"github.com/openbao/consul-template/watch"
+	"github.com/openbao/openbao-template/child"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
+	"github.com/openbao/openbao-template/renderer"
+	"github.com/openbao/openbao-template/template"
+	"github.com/openbao/openbao-template/watch"
 
 	multierror "github.com/hashicorp/go-multierror"
 )
@@ -1033,35 +1033,35 @@ func (r *Runner) childEnv() []string {
 	m := make(map[string]string)
 
 	if config.StringPresent(r.config.Vault.Address) {
-		m["VAULT_ADDR"] = config.StringVal(r.config.Vault.Address)
+		m["BAO_ADDR"] = config.StringVal(r.config.Vault.Address)
 	}
 
 	if !config.BoolVal(r.config.Vault.SSL.Verify) {
-		m["VAULT_SKIP_VERIFY"] = "true"
+		m["BAO_SKIP_VERIFY"] = "true"
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.Cert) {
-		m["VAULT_CLIENT_CERT"] = config.StringVal(r.config.Vault.SSL.Cert)
+		m["BAO_CLIENT_CERT"] = config.StringVal(r.config.Vault.SSL.Cert)
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.Key) {
-		m["VAULT_CLIENT_KEY"] = config.StringVal(r.config.Vault.SSL.Key)
+		m["BAO_CLIENT_KEY"] = config.StringVal(r.config.Vault.SSL.Key)
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.CaPath) {
-		m["VAULT_CAPATH"] = config.StringVal(r.config.Vault.SSL.CaPath)
+		m["BAO_CAPATH"] = config.StringVal(r.config.Vault.SSL.CaPath)
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.CaCert) {
-		m["VAULT_CACERT"] = config.StringVal(r.config.Vault.SSL.CaCert)
+		m["BAO_CACERT"] = config.StringVal(r.config.Vault.SSL.CaCert)
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.CaCertBytes) {
-		m["VAULT_CACERT_BYTES"] = config.StringVal(r.config.Vault.SSL.CaCertBytes)
+		m["BAO_CACERT_BYTES"] = config.StringVal(r.config.Vault.SSL.CaCertBytes)
 	}
 
 	if config.StringPresent(r.config.Vault.SSL.ServerName) {
-		m["VAULT_TLS_SERVER_NAME"] = config.StringVal(r.config.Vault.SSL.ServerName)
+		m["BAO_TLS_SERVER_NAME"] = config.StringVal(r.config.Vault.SSL.ServerName)
 	}
 
 	// Append runner-supplied env (this is supplied programmatically).

--- a/manager/runner_test.go
+++ b/manager/runner_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbao/consul-template/child"
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
-	"github.com/openbao/consul-template/template"
+	"github.com/openbao/openbao-template/child"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
+	"github.com/openbao/openbao-template/template"
 )
 
 func TestRunner_initTemplates(t *testing.T) {
@@ -466,7 +466,7 @@ func TestRunner_Run(t *testing.T) {
 				},
 			},
 			func(t *testing.T, r *Runner, out string) {
-				exp := "VAULT_ADDR=1.2.3.4"
+				exp := "BAO_ADDR=1.2.3.4"
 				if !strings.Contains(out, exp) {
 					t.Errorf("\nexp: %#v\nact: %#v", exp, out)
 				}

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -16,8 +16,10 @@ var SIGNULL os.Signal = syscall.Signal(0)
 
 // ValidSignals is the list of all valid signals. This is built at runtime
 // because it is OS-dependent.
-var ValidSignals []string
-var MonitoredSignals []os.Signal
+var (
+	ValidSignals     []string
+	MonitoredSignals []os.Signal
+)
 
 func init() {
 	valid := make([]string, 0, len(SignalLookup))

--- a/template/brain.go
+++ b/template/brain.go
@@ -6,7 +6,7 @@ package template
 import (
 	"sync"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 )
 
 // Brain is what Template uses to determine the values that are

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -34,7 +34,8 @@ import (
 	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v2"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
+	"github.com/openbao/openbao/api"
 )
 
 // now is function that represents the current time in UTC. This is here
@@ -53,7 +54,7 @@ func envFunc(env []string) func(string) (string, error) {
 				return v, nil
 			}
 		}
-		return os.Getenv(s), nil
+		return api.ReadBaoVariable(s), nil
 	}
 }
 
@@ -96,7 +97,7 @@ func envWithDefaultFunc(env []string) func(string, string) (string, error) {
 				return v, nil
 			}
 		}
-		val, isPresent := os.LookupEnv(s)
+		val, isPresent := api.LookupBaoVariable(s)
 		if isPresent {
 			return val, nil
 		}

--- a/template/template.go
+++ b/template/template.go
@@ -13,8 +13,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 )

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/stretchr/testify/require"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ package version
 import "fmt"
 
 const (
-	Version           = "0.35.0"
+	Version           = "0.36.0"
 	VersionPrerelease = "" // "-dev", "-beta", "-rc1", etc. (include dash)
 )
 
 var (
-	Name      string = "consul-template"
+	Name      string = "openbao-template"
 	GitCommit string
 
 	HumanVersion = fmt.Sprintf("%s v%s%s (%s)",

--- a/watch/dependencies_test.go
+++ b/watch/dependencies_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 )
 
 // TestDep is a special dependency that does not actually speaks to a server.

--- a/watch/vault_token.go
+++ b/watch/vault_token.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/openbao/openbao/api"
 )
 

--- a/watch/vault_token_test.go
+++ b/watch/vault_token_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openbao/consul-template/config"
-	dep "github.com/openbao/consul-template/dependency"
+	"github.com/openbao/openbao-template/config"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/openbao/openbao/api"
 )
 

--- a/watch/view.go
+++ b/watch/view.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 )
 
 var errLookup = fmt.Errorf("lookup error")

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/openbao/openbao/api"
 )
 
@@ -132,7 +132,7 @@ func vaultTokenSetup(clients *dep.ClientSet) string {
 // returns path to token file (which is created by the agent run)
 // token file isn't cleaned, so use returned path to remove it when done
 func runVaultAgent(clients *dep.ClientSet, role_id string) string {
-	dir, err := os.MkdirTemp("", "consul-template-test")
+	dir, err := os.MkdirTemp("", "openbao-template-test")
 	if err != nil {
 		panic(err)
 	}

--- a/watch/watcher.go
+++ b/watch/watcher.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 	"github.com/pkg/errors"
 )
 

--- a/watch/watcher_test.go
+++ b/watch/watcher_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	dep "github.com/openbao/consul-template/dependency"
+	dep "github.com/openbao/openbao-template/dependency"
 )
 
 func TestAdd_updatesMap(t *testing.T) {


### PR DESCRIPTION
This replaces the name `consul-template` in many places, switching to `openbao-template`. Note that non-code instances of `consul-template` were not yet removed.

This also updates environment variables to use the new API helpers (`api.ReadBaoVariable(...)`) and to use the new `BAO_` prefix which will auto-detect for `VAULT_` prefixes.

Technically this latter is a breaking change: the config of `openbao-template` now outputs in `BAO`-prefixed variables regardless of server to template against.

---

@naphelps after this change lands, I think you'll need to rename this repo to `openbao-template` if you don't mind :-)