### PR TITLE
fix: treat KVv2 secrets with future deletion_time as valid, not deleted

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -174,11 +174,26 @@ func (d *VaultReadQuery) readSecret(clients *ClientSet) (*api.Secret, error) {
 }
 
 func deletedKVv2(s *api.Secret) bool {
-	switch md := s.Data["metadata"].(type) {
-	case map[string]interface{}:
-		return md["deletion_time"] != ""
+	md, ok := s.Data["metadata"].(map[string]interface{})
+	if !ok {
+		return false
 	}
-	return false
+
+	dtStr, ok := md["deletion_time"].(string)
+	if !ok || dtStr == "" {
+		return false
+	}
+
+	// With delete_version_after set, secrets get a future deletion_time at
+	// creation time. Only treat as deleted if the deletion_time is in the past.
+	// This mirrors the check in the KVv2 backend's pathDataRead handler.
+	dt, err := time.Parse(time.RFC3339Nano, dtStr)
+	if err != nil {
+		// If we can't parse it, assume it's deleted to be safe.
+		return true
+	}
+
+	return dt.Before(time.Now())
 }
 
 // shimKVv2Path aligns the supported legacy path to KV v2 specs by inserting


### PR DESCRIPTION
When delete_version_after is configured on a KVv2 mount or key metadata,
secrets are created with a future deletion_time timestamp. The deletedKVv2
function was treating any non-empty deletion_time as deleted, which caused
template rendering to fail with no secret exists when the agent tried
to read a version that had a future deletion_time.

Now we parse the deletion_time string and only consider the secret deleted
if the deletion_time is actually in the past, matching the semantic used
by the KVv2 backend pathDataRead handler.

Fixes openbao/openbao#2872